### PR TITLE
Work Orders Table Improvement

### DIFF
--- a/src/app/components/workorders-table/workorders-table.component.css
+++ b/src/app/components/workorders-table/workorders-table.component.css
@@ -5,7 +5,6 @@ table {
   th.mat-sort-header-sorted {
     color: black;
   }
-
   .example-form {
     min-width: 150px;
     max-width: 500px;
@@ -15,3 +14,48 @@ table {
   .example-full-width {
     width: 100%;
   }
+  
+  tr.example-detail-row {
+    height: 0;
+  }
+  
+  tr.example-element-row:not(.example-expanded-row):hover {
+    background: whitesmoke;
+  }
+  
+  tr.example-element-row:not(.example-expanded-row):active {
+    background: #efefef;
+  }
+  
+  .example-element-row td {
+    border-bottom-width: 0;
+  }
+  
+  .example-element-detail {
+    overflow: hidden;
+    display: flex;
+  }
+  
+  .example-element-diagram {
+    min-width: 80px;
+    border: 2px solid black;
+    padding: 8px;
+    font-weight: lighter;
+    margin: 8px 0;
+    height: 104px;
+  }
+  
+  .example-element-symbol {
+    font-weight: bold;
+    font-size: 40px;
+    line-height: normal;
+  }
+  
+  .example-element-description {
+    padding: 16px;
+  }
+  
+  .example-element-description-attribution {
+    opacity: 0.5;
+  }
+  

--- a/src/app/components/workorders-table/workorders-table.component.html
+++ b/src/app/components/workorders-table/workorders-table.component.html
@@ -6,17 +6,17 @@
 </mat-form-field>
 <div class="mat-elevation-z8">
 
-    <table mat-table [dataSource]="dataSource" matSort>
+    <table mat-table [dataSource]="dataSource" multiTemplateDataRows matSort>
 
         <!--- Note that these columns can be defined in any order.
           The actual rendered columns are set as a property on the row definition" -->
 
-        <!-- ID Column -->
+        <!-- ID Column 
         <ng-container matColumnDef="id">
             <th mat-header-cell *matHeaderCellDef mat-sort-header> Work Order ID </th>
             <td mat-cell *matCellDef="let element"> {{element.id}} </td>
         </ng-container>
-
+            -->
         <!-- Title Column -->
         <ng-container matColumnDef="title">
             <th mat-header-cell *matHeaderCellDef mat-sort-header> Title </th>
@@ -41,9 +41,33 @@
             <td mat-cell *matCellDef="let element"> {{element.addressDistrict}} </td>
         </ng-container>
 
+        <!-- Expanded Content Column - The detail row is made up of this one column that spans across all columns -->
+        <ng-container matColumnDef="expandedDetail">
+            <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+              <div class="example-element-detail"
+                   [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
+                <div class="example-element-diagram">
+                  <div class="example-element-position"> {{element.type}} </div>
+                  <div class="example-element-symbol"> {{element.addressDistrict}} </div>
+                  <div class="example-element-name"> {{element.addressCity}} </div>
+                </div>
+                <div class="example-element-description">
+                  Job Description: {{element.description}} <br>
+                  Open Address: {{element.openAddress}} <br>
+                  Telephone: {{element.telephone}}
+                </div>
+                <button mat-raised-button color="primary"
+                (click)="getTheJobButtonClick(element)">Get The Job</button>
+              </div>
+            </td>
+          </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        <tr mat-row *matRowDef="let element; columns: displayedColumns;"
+        class="example-element-row"
+        [class.example-expanded-row]="expandedElement === element"
+        (click)="expandedElement = expandedElement === element ? null : element"></tr>
+        <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="example-detail-row"></tr>
     </table>
 
     <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>

--- a/src/app/components/workorders-table/workorders-table.component.ts
+++ b/src/app/components/workorders-table/workorders-table.component.ts
@@ -3,18 +3,28 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
-import {FormControl, Validators} from '@angular/forms';
 import { WorkOrders } from 'src/app/shared/services/workorders';
+import {animate, state, style, transition, trigger} from '@angular/animations';
+import { stringify } from '@angular/compiler/src/util';
+
 @Component({
   selector: 'app-workorders-table',
   templateUrl: './workorders-table.component.html',
-  styleUrls: ['./workorders-table.component.css']
+  styleUrls: ['./workorders-table.component.css'],
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed', style({height: '0px', minHeight: '0'})),
+      state('expanded', style({height: '*'})),
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
 })
 export class WorkordersTableComponent implements OnInit {
 
   ELEMENT_DATA : WorkOrders[];
-  displayedColumns: string[] = ['id', 'title', 'type', 'addressCity', 'addressDistrict'];
+  displayedColumns: string[] = [ 'title', 'type', 'addressCity', 'addressDistrict'];
   dataSource;
+  expandedElement: WorkOrders | null;
 
   constructor(private service:WorkordersTableService) { }
 
@@ -39,4 +49,10 @@ export class WorkordersTableComponent implements OnInit {
     this.dataSource.filter = filterValue.trim().toLowerCase();
   }
 
+  getTheJobButtonClick(workOrder: any){
+    var toReplaced = /\"status\":0/gi;
+    var workOrderJson = JSON.stringify(workOrder).replace(toReplaced, "\"status\":1" );
+    var json = JSON.parse(workOrderJson);
+    this.service.getTheJob(json);
+  }
 }

--- a/src/app/shared/services/workorders-table.service.ts
+++ b/src/app/shared/services/workorders-table.service.ts
@@ -1,5 +1,12 @@
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { HttpHeaders } from '@angular/common/http';
+
+const httpOptions = {
+  headers: new HttpHeaders({
+    'Content-Type':  'application/json'
+  })
+};
 
 
 @Injectable({
@@ -11,6 +18,14 @@ export class WorkordersTableService {
   
   public workorderList(){
   
-    return this.http.get("http://localhost:8080/workorder");
+    return this.http.get("http://localhost:8080/workorder?topicId=pending");
+  }
+
+  public getTheJob(workOrder: any){
+    
+    this.http.post("http://localhost:8080/workorder", workOrder, httpOptions).subscribe(data =>
+    {
+
+    });
   }
 }

--- a/src/app/shared/services/workorders.ts
+++ b/src/app/shared/services/workorders.ts
@@ -1,7 +1,11 @@
 export interface WorkOrders {
-    id: number,
-    title: string,
-    type: string,
+    userId: string,
+    telephone: string,
+    status: number,
     addressCity: string,
-    addressDistrict: string
+    addressDistrict: string,
+    description: string,
+    openAddress: string,
+    title: string,
+    type: string
 }


### PR DESCRIPTION
-Get the job button is added to work orders table for the Workers. This button sends a http POST request to server and change the workorder status 0 to 1 which means now this work order is in progress. 
-Also, table is now have expendable rows. When worker click on the single work order can display the work order details and open address of the job with smooth animation.